### PR TITLE
update macOS runner version for Intel build to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
   # Build for macOS x86_64 (Intel)
   build-macos-x86_64:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
This pull request makes a minor update to the release workflow configuration for macOS builds. The change updates the runner environment to use a newer macOS version for Intel builds. 

* `build-macos-x86_64` job in `.github/workflows/release.yml`: Changed the runner from `macos-13` to `macos-15-intel` to use a more recent macOS version for Intel architecture builds.