### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '30 0 * * 6' # Weekly on Saturday at 00:30 UTC
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/8](https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/8)

In general, the fix is to explicitly define `permissions` for jobs so they do not inherit potentially broad defaults. For this workflow, the simplest and safest approach is to set a restrictive default at the workflow root (e.g., `permissions: contents: read`) and then keep or define broader permissions only where needed (the `security-analysis` job already has its own explicit permissions).

The best fix without changing functionality is:
- Add a root-level `permissions:` block after the `on:` section that sets `contents: read`. This will apply to all jobs that don’t define their own `permissions`.
- Leave the existing `permissions` block on `security-analysis` unchanged; that job already declares the extra scopes it needs (`security-events: write`, `actions: read`).

Concretely:
- Edit `.github/workflows/rust-ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after the `on:` block (after line 9 in the provided snippet). No imports or additional methods are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
