### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,8 @@ jobs:
 
   # Build for Linux (x64 and ARM64 via matrix)
   build-linux:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/5](https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/5)

In general, the fix is to explicitly declare minimal `GITHUB_TOKEN` permissions for jobs that do not need to write to the repository or other resources. For build-only jobs like `build-linux`, setting `permissions: contents: read` at the job level is typically sufficient, because they only need to fetch code and do not modify repository state. This limits the blast radius if any step or action is compromised.

Concretely, in `.github/workflows/release.yml`, we should add a `permissions` block to the `build-linux` job (the one where CodeQL points at `strategy:` on line 214). Place the block right under the job name (`build-linux:`) and before `strategy:` to explicitly restrict the token. Based on the visible steps (checkout, install tools, build, create artifacts, upload-artifact), the job only needs read access to repository contents, so we can safely set:
```yaml
permissions:
  contents: read
```
No new imports or external dependencies are needed; this is purely a workflow YAML change and does not alter the existing behavior of the steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
