### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,8 @@ jobs:
 
   # Build for Windows (x64 and ARM64 via matrix)
   build-windows:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/4](https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/4)

In general, fix this by explicitly defining a `permissions` block for the `build-windows` job (or at the workflow root) so that the `GITHUB_TOKEN` is restricted to the least privileges required. For this specific job, it only needs to read the repository contents for checkout; no steps create releases, modify issues, or push code, so `contents: read` is sufficient.

Concretely, in `.github/workflows/release.yml`, under the `build-windows:` job definition (around line 157), add a `permissions:` section similar to the one already present in `build-linux`. The best minimal configuration is:

```yaml
build-windows:
  permissions:
    contents: read
  strategy:
    ...
```

This preserves existing functionality because none of the steps in `build-windows` require write access to repository contents or other scopes. No imports or additional methods are needed, just this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
