### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ env:
 jobs:
   # Build for macOS (ARM64 and x86_64 via matrix)
   build-macos:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/2](https://github.com/rubentalstra/Trial-Submission-Studio/security/code-scanning/2)

In general, to fix this class of problem you should explicitly set a `permissions` block at the workflow or job level, restricting the GITHUB_TOKEN to only the scopes actually required (commonly `contents: read` for simple build jobs). This avoids inheriting potentially over‑permissive repository defaults.

For this specific workflow, the minimal fix without changing behavior is to add `permissions: contents: read` to the `build-macos` job, mirroring the existing configuration already present on the `build-windows` job. The `build-macos` steps only read source code and push artifacts via `actions/upload-artifact`, which doesn’t require repository write permissions. You don’t need any additional imports or methods; it’s a pure YAML configuration change within `.github/workflows/release.yml`. Insert the new `permissions` block directly under the `build-macos:` key (before `strategy:`) to satisfy CodeQL and enforce least privilege for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
