### PR TITLE
feat: bump version to 0.0.1-alpha.7 and enhance runtime target detection in updater logic

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,5 +44,5 @@ keywords:
   - desktop-application
   - cross-platform
 license: MIT
-version: '0.0.1-alpha.6'
-date-released: '2026-01-04'
+version: '0.0.1-alpha.7'
+date-released: '2026-01-05'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6169,14 +6169,14 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tss-common"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "polars",
 ]
 
 [[package]]
 name = "tss-gui"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "tss-ingest"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "polars",
  "serde",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "tss-map"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "anyhow",
  "rapidfuzz",
@@ -6238,7 +6238,7 @@ dependencies = [
 
 [[package]]
 name = "tss-model"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "tss-output"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6262,7 +6262,7 @@ dependencies = [
 
 [[package]]
 name = "tss-standards"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "csv",
  "serde",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "tss-transform"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "chrono",
  "insta",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "tss-updater"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "chrono",
  "self_update",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "tss-validate"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "csv",
  "polars",
@@ -6310,7 +6310,7 @@ dependencies = [
 
 [[package]]
 name = "tss-xpt"
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 dependencies = [
  "chrono",
  "polars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.0.1-alpha.6"
+version = "0.0.1-alpha.7"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT"


### PR DESCRIPTION
This pull request improves the update mechanism in the `tss-updater` crate by ensuring that the correct platform-specific binary is always downloaded at runtime, regardless of how the application was built. It does this by dynamically constructing the target triple using runtime environment constants, and updates both the update logic and tests accordingly. Additionally, version numbers are bumped across metadata files.

**Updater logic improvements:**

* Added a `get_runtime_target` function to dynamically construct the target triple at runtime using `std::env::consts`, ensuring correct asset downloads even for cross-compiled binaries (`crates/tss-updater/src/lib.rs`).
* Updated the `UpdateService` methods to use the runtime target triple for both update checks and downloads, and improved log messages to reflect the runtime target (`crates/tss-updater/src/lib.rs`). [[1]](diffhunk://#diff-77f5bbf4296f8aeb7698efe364a307e13bc0d96f69cca621d8e1e5a753ee4e3cR96-R103) [[2]](diffhunk://#diff-77f5bbf4296f8aeb7698efe364a307e13bc0d96f69cca621d8e1e5a753ee4e3cL136-R175)

**Testing:**

* Added a new test to verify that the runtime target detection logic produces the correct architecture and OS-specific suffix for different platforms (`crates/tss-updater/src/lib.rs`).

**Version and metadata updates:**

* Bumped version numbers from `0.0.1-alpha.6` to `0.0.1-alpha.7` in `Cargo.toml` and `CITATION.cff`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L18-R18) [[2]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295L47-R48)