### PR TITLE
Fix/can't load the study folder

### DIFF
--- a/crates/tss-gui/src/handler/dialog.rs
+++ b/crates/tss-gui/src/handler/dialog.rs
@@ -160,8 +160,8 @@ fn handle_settings_message(state: &mut AppState, msg: SettingsMessage) -> Task<M
                     state.settings.export.xpt_version = version;
                 }
                 ExportSettingsMessage::SdtmIgVersionChanged(version) => {
-                    state.settings.export.sdtm_ig_version = version;
-                    tracing::info!("SDTM-IG version: {}", version);
+                    state.settings.export.ig_version = version;
+                    tracing::info!("IG version: {}", version);
                 }
             }
             Task::none()

--- a/crates/tss-gui/src/handler/export.rs
+++ b/crates/tss-gui/src/handler/export.rs
@@ -255,7 +255,7 @@ fn start_export(state: &mut AppState) -> Task<Message> {
         output_dir,
         format: state.settings.export.default_format,
         xpt_version: state.settings.export.xpt_version,
-        sdtm_ig_version: state.settings.export.sdtm_ig_version,
+        ig_version: state.settings.export.ig_version,
         domains: domain_data,
         study_id,
         bypass_validation: state.settings.developer.bypass_validation,

--- a/crates/tss-gui/src/handler/project.rs
+++ b/crates/tss-gui/src/handler/project.rs
@@ -126,11 +126,13 @@ pub fn handle_open_project_selected(state: &mut AppState, path: Option<PathBuf>)
 
 /// Handle a loaded project file.
 ///
-/// This is complex because we need to:
-/// 1. Reload source CSV files from their original paths
-/// 2. Recreate MappingState with fresh suggestions
-/// 3. Apply saved decisions (accepted, not_collected, omitted, auto_generated)
-/// 4. Restore SUPP configurations
+/// When loading a project:
+/// 1. Build assignments from saved source_assignments (skip assignment screen)
+/// 2. Create Study directly using create_study_from_assignments
+/// 3. StudyLoaded handler will apply saved mappings from pending_project_restore
+///
+/// Note: If source files are missing, we show an error instead of falling back
+/// to the assignment screen.
 pub fn handle_project_loaded(
     state: &mut AppState,
     result: Result<(PathBuf, tss_persistence::ProjectFile), String>,
@@ -145,21 +147,87 @@ pub fn handle_project_loaded(
                 project.study.study_folder
             );
 
+            // Check if there are source assignments to restore
+            if project.source_assignments.is_empty() {
+                tracing::warn!("Project has no source assignments - cannot restore study");
+                state.error = Some(crate::error::GuiError::operation(
+                    "Load project",
+                    "Project has no source file assignments. Please create a new project.",
+                ));
+                return Task::none();
+            }
+
+            // Build assignments map from saved source_assignments
+            let mut assignments: std::collections::BTreeMap<String, PathBuf> =
+                std::collections::BTreeMap::new();
+            let mut missing_files = Vec::new();
+
+            for assignment in &project.source_assignments {
+                let file_path = PathBuf::from(&assignment.file_path);
+
+                // Check if file exists
+                if !file_path.exists() {
+                    missing_files.push(assignment.file_path.clone());
+                    continue;
+                }
+
+                assignments.insert(assignment.domain_code.clone(), file_path);
+            }
+
+            // If any source files are missing, show error
+            if !missing_files.is_empty() {
+                tracing::error!("Source files missing: {:?}", missing_files);
+                let msg = format!(
+                    "Cannot load project - {} source file(s) not found:\n{}",
+                    missing_files.len(),
+                    missing_files
+                        .iter()
+                        .take(3) // Show at most 3 files
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                );
+                state.error = Some(crate::error::GuiError::operation("Load project", msg));
+                return Task::none();
+            }
+
+            // Convert workflow type from persistence to GUI type
+            let workflow_mode = match project.study.workflow_type {
+                WorkflowTypeSnapshot::Sdtm => crate::state::WorkflowMode::Sdtm,
+                WorkflowTypeSnapshot::Adam => crate::state::WorkflowMode::Adam,
+                WorkflowTypeSnapshot::Send => crate::state::WorkflowMode::Send,
+            };
+
             // Store the project path for future saves
             state.project_path = Some(project_path.clone());
 
-            let study_folder = PathBuf::from(&project.study.study_folder);
-
             // Store the project data for restoration after study loading completes
             // The StudyLoaded handler will check for this and apply the saved mappings
-            state.pending_project_restore = Some((project_path, project));
+            state.pending_project_restore = Some((project_path, project.clone()));
 
             // Reset dirty tracker since we're loading a saved project
             state.dirty_tracker = tss_persistence::DirtyTracker::new();
 
-            // Trigger study loading from the folder
-            // After StudyLoaded completes, we'll apply the saved mappings
-            crate::handler::home::load_study(state, study_folder)
+            // Get settings for study creation
+            let folder = PathBuf::from(&project.study.study_folder);
+            let header_rows = state.settings.general.header_rows;
+            let confidence_threshold = state.settings.general.mapping_confidence_threshold;
+
+            // Set loading state
+            state.is_loading = true;
+
+            // Create study directly from saved assignments (skip assignment screen)
+            Task::perform(
+                crate::service::study::create_study_from_assignments(
+                    folder,
+                    assignments,
+                    Vec::new(), // No metadata files - they were already incorporated
+                    header_rows,
+                    confidence_threshold,
+                    workflow_mode,
+                ),
+                Message::StudyLoaded,
+            )
         }
         Err(e) => {
             tracing::error!("Failed to load project: {}", e);

--- a/crates/tss-gui/src/handler/project.rs
+++ b/crates/tss-gui/src/handler/project.rs
@@ -404,13 +404,14 @@ fn create_project_file_from_state(study: &crate::state::Study, state: &AppState)
             snapshot.label = domain_state.source.label.clone();
 
             // Create mapping snapshot
+            // Note: We discard confidence scores - they're only meaningful during active mapping
             let mapping = &domain_state.mapping;
             let mapping_snapshot = MappingSnapshot {
                 study_id: mapping.study_id().to_string(),
                 accepted: mapping
                     .all_accepted()
                     .iter()
-                    .map(|(var, (col, conf))| (var.clone(), MappingEntry::new(col.clone(), *conf)))
+                    .map(|(var, (col, _conf))| (var.clone(), MappingEntry::new(col.clone())))
                     .collect(),
                 not_collected: mapping.all_not_collected().clone(),
                 omitted: mapping.all_omitted().clone(),

--- a/crates/tss-gui/src/service/export.rs
+++ b/crates/tss-gui/src/service/export.rs
@@ -331,15 +331,8 @@ fn write_dataset_xml_file(
         ..Default::default()
     };
 
-    write_dataset_xml_output(
-        path,
-        domain,
-        frame,
-        study_id,
-        ig_version,
-        Some(&options),
-    )
-    .map_err(|e| ExportError::new(format!("Failed to write Dataset-XML: {}", e)))?;
+    write_dataset_xml_output(path, domain, frame, study_id, ig_version, Some(&options))
+        .map_err(|e| ExportError::new(format!("Failed to write Dataset-XML: {}", e)))?;
 
     Ok(())
 }

--- a/crates/tss-gui/src/service/export.rs
+++ b/crates/tss-gui/src/service/export.rs
@@ -39,8 +39,8 @@ pub struct ExportInput {
     /// TODO: Pass this to the XPT writer when version support is implemented in tss-submit.
     #[allow(dead_code)]
     pub xpt_version: XptVersion,
-    /// SDTM-IG version for Dataset-XML and Define-XML.
-    pub sdtm_ig_version: SdtmIgVersion,
+    /// Implementation Guide version for Dataset-XML and Define-XML.
+    pub ig_version: SdtmIgVersion,
     /// Domains to export with their data.
     pub domains: Vec<DomainExportData>,
     /// Study ID (extracted from data or default).
@@ -193,7 +193,7 @@ fn execute_export_sync(input: ExportInput) -> ExportResult {
         );
         let path = datasets_dir.join(&filename);
 
-        let ig_version = input.sdtm_ig_version.as_str();
+        let ig_version = input.ig_version.as_str();
         if let Err(e) = write_data_file(
             &path,
             &frame,
@@ -251,7 +251,7 @@ fn execute_export_sync(input: ExportInput) -> ExportResult {
 
     // Write Define-XML (always required)
     let define_path = datasets_dir.join("define.xml");
-    let ig_version = input.sdtm_ig_version.as_str();
+    let ig_version = input.ig_version.as_str();
     if let Err(e) = write_define_xml(
         &define_path,
         &input.study_id,
@@ -286,12 +286,12 @@ fn write_data_file(
     domain: &SdtmDomain,
     study_id: &str,
     format: ExportFormat,
-    sdtm_ig_version: &str,
+    ig_version: &str,
 ) -> Result<(), ExportError> {
     match format {
         ExportFormat::Xpt => write_xpt_file(path, frame, domain),
         ExportFormat::DatasetXml => {
-            write_dataset_xml_file(path, frame, domain, study_id, sdtm_ig_version)
+            write_dataset_xml_file(path, frame, domain, study_id, ig_version)
         }
     }
 }
@@ -324,7 +324,7 @@ fn write_dataset_xml_file(
     frame: &DomainFrame,
     domain: &SdtmDomain,
     study_id: &str,
-    sdtm_ig_version: &str,
+    ig_version: &str,
 ) -> Result<(), ExportError> {
     let options = DatasetXmlOptions {
         dataset_name: Some(frame.dataset_name()),
@@ -336,7 +336,7 @@ fn write_dataset_xml_file(
         domain,
         frame,
         study_id,
-        sdtm_ig_version,
+        ig_version,
         Some(&options),
     )
     .map_err(|e| ExportError::new(format!("Failed to write Dataset-XML: {}", e)))?;
@@ -351,7 +351,7 @@ fn write_define_xml(
     domain_data: &[DomainExportData],
     domain_frames: &[DomainFrame],
     supp_frames: &[DomainFrame],
-    sdtm_ig_version: &str,
+    ig_version: &str,
 ) -> Result<(), ExportError> {
     // Collect all domains and frames
     let mut domains: Vec<SdtmDomain> = domain_data.iter().map(|d| d.definition.clone()).collect();
@@ -378,7 +378,7 @@ fn write_define_xml(
         all_frames.push(supp_frame.clone());
     }
 
-    let options = DefineXmlOptions::new(sdtm_ig_version, "Submission");
+    let options = DefineXmlOptions::new(ig_version, "Submission");
 
     write_define_xml_output(path, study_id, &domains, &all_frames, &options)
         .map_err(|e| ExportError::new(format!("Failed to write Define-XML: {}", e)))?;

--- a/crates/tss-gui/src/state/settings.rs
+++ b/crates/tss-gui/src/state/settings.rs
@@ -367,8 +367,8 @@ pub struct ExportSettings {
     /// XPT version for SAS transport files.
     pub xpt_version: XptVersion,
 
-    /// SDTM-IG version for Dataset-XML and Define-XML.
-    pub sdtm_ig_version: SdtmIgVersion,
+    /// Implementation Guide version for Dataset-XML and Define-XML.
+    pub ig_version: SdtmIgVersion,
 }
 
 impl Default for ExportSettings {
@@ -378,7 +378,7 @@ impl Default for ExportSettings {
             last_export_dir: None,
             include_define_xml: true,
             xpt_version: XptVersion::default(),
-            sdtm_ig_version: SdtmIgVersion::default(),
+            ig_version: SdtmIgVersion::default(),
         }
     }
 }

--- a/crates/tss-gui/src/view/dialog/settings.rs
+++ b/crates/tss-gui/src/view/dialog/settings.rs
@@ -434,7 +434,7 @@ fn view_export_settings(settings: &Settings) -> Element<'_, Message> {
         Space::new().height(SPACING_XS),
         pick_list(
             crate::state::SdtmIgVersion::ALL.to_vec(),
-            Some(settings.export.sdtm_ig_version),
+            Some(settings.export.ig_version),
             |v| Message::Dialog(DialogMessage::Settings(SettingsMessage::Export(
                 ExportSettingsMessage::SdtmIgVersionChanged(v),
             )))

--- a/crates/tss-persistence/src/convert.rs
+++ b/crates/tss-persistence/src/convert.rs
@@ -50,6 +50,10 @@ pub trait FromSnapshot: Sized {
 /// This is called by GUI code that has access to MappingState.
 /// We can't implement ToSnapshot directly on MappingState because
 /// it's defined in tss-submit.
+///
+/// Note: The `accepted` parameter includes confidence scores from the session,
+/// but we intentionally discard them - confidence is only meaningful during
+/// active mapping, not for persistence.
 pub fn mapping_to_snapshot(
     study_id: &str,
     accepted: &BTreeMap<String, (String, f32)>,
@@ -61,7 +65,7 @@ pub fn mapping_to_snapshot(
         study_id: study_id.to_string(),
         accepted: accepted
             .iter()
-            .map(|(var, (col, conf))| (var.clone(), MappingEntry::new(col.clone(), *conf)))
+            .map(|(var, (col, _conf))| (var.clone(), MappingEntry::new(col.clone())))
             .collect(),
         not_collected: not_collected.clone(),
         omitted: omitted.clone(),

--- a/crates/tss-persistence/src/types/domain.rs
+++ b/crates/tss-persistence/src/types/domain.rs
@@ -98,23 +98,23 @@ impl MappingSnapshot {
 }
 
 /// A single mapping entry.
+///
+/// Note: Confidence is intentionally NOT stored. Confidence is only meaningful
+/// during a mapping session (showing how confident the suggestion algorithm is).
+/// Once a user accepts a mapping, they've validated it - the confidence score
+/// becomes meaningless. It's transient GUI state, not persisted data.
 #[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 #[rkyv(compare(PartialEq))]
 pub struct MappingEntry {
     /// Source column name.
     pub source_column: String,
-
-    /// Confidence score (0.0 to 1.0).
-    /// 1.0 for manual mappings, lower for auto-suggested.
-    pub confidence: f32,
 }
 
 impl MappingEntry {
     /// Create a new mapping entry.
-    pub fn new(source_column: impl Into<String>, confidence: f32) -> Self {
+    pub fn new(source_column: impl Into<String>) -> Self {
         Self {
             source_column: source_column.into(),
-            confidence,
         }
     }
 }

--- a/crates/tss-persistence/src/types/project.rs
+++ b/crates/tss-persistence/src/types/project.rs
@@ -83,8 +83,9 @@ pub struct StudyMetadata {
     /// Workflow type (SDTM, ADaM, SEND).
     pub workflow_type: WorkflowTypeSnapshot,
 
-    /// SDTM-IG version used.
-    pub sdtm_ig_version: String,
+    /// Implementation Guide version used (e.g., "3.4" for SDTM-IG 3.4).
+    /// Applies to SDTM, ADaM, and SEND workflows.
+    pub ig_version: String,
 
     /// Controlled Terminology version used.
     pub ct_version: Option<String>,
@@ -101,7 +102,7 @@ impl StudyMetadata {
             study_id: study_id.into(),
             study_folder: study_folder.into(),
             workflow_type,
-            sdtm_ig_version: "3.4".to_string(),
+            ig_version: "3.4".to_string(),
             ct_version: None,
         }
     }

--- a/crates/tss-submit/src/export/dataset_xml.rs
+++ b/crates/tss-submit/src/export/dataset_xml.rs
@@ -33,7 +33,7 @@ pub fn write_dataset_xml_outputs(
     domains: &[SdtmDomain],
     frames: &[DomainFrame],
     study_id: &str,
-    sdtm_ig_version: &str,
+    ig_version: &str,
 ) -> Result<Vec<PathBuf>> {
     let domain_lookup = domain_map_by_code(domains);
     let mut frames_sorted: Vec<&DomainFrame> = frames.iter().collect();
@@ -57,14 +57,7 @@ pub fn write_dataset_xml_outputs(
             dataset_name: Some(output_dataset_name),
             ..Default::default()
         };
-        write_dataset_xml(
-            &path,
-            domain,
-            frame,
-            study_id,
-            sdtm_ig_version,
-            Some(&options),
-        )?;
+        write_dataset_xml(&path, domain, frame, study_id, ig_version, Some(&options))?;
         outputs.push(path);
     }
     Ok(outputs)
@@ -76,7 +69,7 @@ pub fn write_dataset_xml(
     domain: &SdtmDomain,
     frame: &DomainFrame,
     study_id: &str,
-    sdtm_ig_version: &str,
+    ig_version: &str,
     options: Option<&DatasetXmlOptions>,
 ) -> Result<()> {
     let options = options.cloned().unwrap_or_default();
@@ -87,7 +80,7 @@ pub fn write_dataset_xml(
     let study_oid = format!("STDY.{study_id}");
     let mdv_oid = options
         .metadata_version_oid
-        .unwrap_or_else(|| format!("MDV.{study_oid}.SDTMIG.{sdtm_ig_version}"));
+        .unwrap_or_else(|| format!("MDV.{study_oid}.SDTMIG.{ig_version}"));
     let define_file_oid = format!("{study_oid}.Define-XML_{DEFINE_XML_VERSION}");
     let file_oid = format!("{define_file_oid}(IG.{dataset_name})");
     let is_reference = options

--- a/crates/tss-submit/src/export/define_xml.rs
+++ b/crates/tss-submit/src/export/define_xml.rs
@@ -24,14 +24,15 @@ use super::common::{
 /// Options for Define-XML output.
 #[derive(Debug, Clone)]
 pub struct DefineXmlOptions {
-    pub sdtm_ig_version: String,
+    /// Implementation Guide version (e.g., "3.4" for SDTM-IG 3.4).
+    pub ig_version: String,
     pub context: String,
 }
 
 impl DefineXmlOptions {
-    pub fn new(sdtm_ig_version: impl Into<String>, context: impl Into<String>) -> Self {
+    pub fn new(ig_version: impl Into<String>, context: impl Into<String>) -> Self {
         Self {
-            sdtm_ig_version: sdtm_ig_version.into(),
+            ig_version: ig_version.into(),
             context: context.into(),
         }
     }
@@ -84,7 +85,7 @@ pub fn write_define_xml(
     let study_id = normalize_study_id(study_id);
     let study_oid = format!("STDY.{study_id}");
     let file_oid = format!("{study_oid}.Define-XML_{DEFINE_XML_VERSION}");
-    let mdv_oid = format!("MDV.{study_oid}.SDTMIG.{}", options.sdtm_ig_version);
+    let mdv_oid = format!("MDV.{study_oid}.SDTMIG.{}", options.ig_version);
     let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
 
     let domain_lookup = domain_map_by_code(domains);
@@ -186,7 +187,7 @@ pub fn write_define_xml(
     let mdv_name = format!("Study {study_id}, Data Definitions");
     let mdv_desc = format!(
         "SDTM {} metadata definitions for {study_id}",
-        options.sdtm_ig_version
+        options.ig_version
     );
     metadata.push_attribute(("Name", mdv_name.as_str()));
     metadata.push_attribute(("Description", mdv_desc.as_str()));

--- a/docs/src/architecture/crates/tss-gui.md
+++ b/docs/src/architecture/crates/tss-gui.md
@@ -348,7 +348,7 @@ pub struct Settings {
     pub recent_studies: Vec<RecentStudy>,
     pub default_export_dir: Option<PathBuf>,
     pub workflow_type: WorkflowType,
-    pub sdtm_ig_version: SdtmIgVersion,
+    pub ig_version: SdtmIgVersion,
     pub xpt_version: XptVersion,
     pub export_format: ExportFormat,
     // Display settings, validation settings, etc.


### PR DESCRIPTION
This pull request refactors the handling of the "Implementation Guide version" (previously called "SDTM-IG version") throughout the codebase, improving clarity and consistency by renaming fields, parameters, and variables. It also updates the project loading workflow to skip the assignment screen and directly restore studies from saved assignments, with improved error handling for missing source files. Additionally, it simplifies mapping persistence by removing confidence scores from saved mappings, reflecting their transient nature.

- Issue: #108

**Implementation Guide Version Refactor:**
* Renamed all instances of `sdtm_ig_version` to `ig_version` in settings, state, export structures, service functions, and persistence types, ensuring consistent terminology for the Implementation Guide version across SDTM, ADaM, and SEND workflows. [[1]](diffhunk://#diff-e3f38521b70bcfa84bf62e86e16bc0a9354efbfb62b7f126081b1773555077edL163-R164) [[2]](diffhunk://#diff-93504cbd871d85d2061a7f32af1b65da5aa3ebc7c00601a47877b8a4ce1ae118L258-R258) [[3]](diffhunk://#diff-3c82bd37367fc65325e64249d9ebc5d4282fb0c079e798be4f2c81ae22de22ecL42-R43) [[4]](diffhunk://#diff-3c82bd37367fc65325e64249d9ebc5d4282fb0c079e798be4f2c81ae22de22ecL196-R196) [[5]](diffhunk://#diff-3c82bd37367fc65325e64249d9ebc5d4282fb0c079e798be4f2c81ae22de22ecL254-R254) [[6]](diffhunk://#diff-3c82bd37367fc65325e64249d9ebc5d4282fb0c079e798be4f2c81ae22de22ecL289-R294) [[7]](diffhunk://#diff-3c82bd37367fc65325e64249d9ebc5d4282fb0c079e798be4f2c81ae22de22ecL327-R334) [[8]](diffhunk://#diff-3c82bd37367fc65325e64249d9ebc5d4282fb0c079e798be4f2c81ae22de22ecL354-R347) [[9]](diffhunk://#diff-3c82bd37367fc65325e64249d9ebc5d4282fb0c079e798be4f2c81ae22de22ecL381-R374) [[10]](diffhunk://#diff-1a352de68ff20a8c9a6e1654be112e363a2f96f229e1f4a589788701d35a9357L370-R371) [[11]](diffhunk://#diff-1a352de68ff20a8c9a6e1654be112e363a2f96f229e1f4a589788701d35a9357L381-R381) [[12]](diffhunk://#diff-ec7cdaafa5e412a8f90a243fe09874bf565dd6cb3d36f2f952eb7c4ecb615553L437-R437) [[13]](diffhunk://#diff-09841fa7306c2480c146538e0aa7e9b8046d5787561639131dba2418dd34d2beL86-R88) [[14]](diffhunk://#diff-09841fa7306c2480c146538e0aa7e9b8046d5787561639131dba2418dd34d2beL104-R105) [[15]](diffhunk://#diff-5b09bb85e9126036bf6e0c913acf2e77e5b6e52adae7f9acc674c1d11b7f3ca3L36-R36) [[16]](diffhunk://#diff-5b09bb85e9126036bf6e0c913acf2e77e5b6e52adae7f9acc674c1d11b7f3ca3L60-R60) [[17]](diffhunk://#diff-5b09bb85e9126036bf6e0c913acf2e77e5b6e52adae7f9acc674c1d11b7f3ca3L79-R72) [[18]](diffhunk://#diff-5b09bb85e9126036bf6e0c913acf2e77e5b6e52adae7f9acc674c1d11b7f3ca3L90-R83) [[19]](diffhunk://#diff-4b55a4acc8a710f7598c392da80be0c2ff14386a72afd4b1abc3bc8660f70295L27-R35)

**Project Loading Workflow Improvements:**
* Updated `handle_project_loaded` to restore studies directly from saved source assignments, skipping the assignment screen, and added error handling to notify users if any source files are missing. [[1]](diffhunk://#diff-9f64afea9dbed8f31dee7d801908be3a35f7bf82c69e067940bbab2661ef6542L129-R135) [[2]](diffhunk://#diff-9f64afea9dbed8f31dee7d801908be3a35f7bf82c69e067940bbab2661ef6542R150-R230)

**Mapping Persistence Simplification:**
* Removed confidence scores from persisted mapping entries and related conversion logic, clarifying that confidence is only relevant during active mapping sessions and not for saved data. [[1]](diffhunk://#diff-9f64afea9dbed8f31dee7d801908be3a35f7bf82c69e067940bbab2661ef6542R475-R482) [[2]](diffhunk://#diff-bc8a4c595bbe10c98aa5ea4c23db9bc127772456ce7ed07b531081fcd10f1644R53-R56) [[3]](diffhunk://#diff-bc8a4c595bbe10c98aa5ea4c23db9bc127772456ce7ed07b531081fcd10f1644L64-R68) [[4]](diffhunk://#diff-4ded20ede084724d41dab69400755239f847b8355ae95ea0fb6d26facf0f3150R101-L117)

**Documentation Updates:**
* Added explanatory comments throughout the codebase to clarify the rationale for discarding confidence scores and the new project loading behavior. [[1]](diffhunk://#diff-9f64afea9dbed8f31dee7d801908be3a35f7bf82c69e067940bbab2661ef6542L129-R135) [[2]](diffhunk://#diff-bc8a4c595bbe10c98aa5ea4c23db9bc127772456ce7ed07b531081fcd10f1644R53-R56) [[3]](diffhunk://#diff-4ded20ede084724d41dab69400755239f847b8355ae95ea0fb6d26facf0f3150R101-L117) [[4]](diffhunk://#diff-09841fa7306c2480c146538e0aa7e9b8046d5787561639131dba2418dd34d2beL86-R88)

These changes improve code clarity, consistency, and user experience when restoring projects and exporting data.