### PR TITLE
feat: implement filter cache rebuilding for mapping, SUPP, and validation

### DIFF
--- a/crates/tss-gui/src/handler/mod.rs
+++ b/crates/tss-gui/src/handler/mod.rs
@@ -52,6 +52,7 @@ use crate::state::AppState;
 // Re-export handlers
 pub use dialog::DialogHandler;
 pub use domain_editor::DomainEditorHandler;
+pub use domain_editor::rebuild_validation_cache;
 pub use export::ExportHandler;
 pub use home::HomeHandler;
 pub use menu::MenuActionHandler;

--- a/crates/tss-gui/src/state/view_state.rs
+++ b/crates/tss-gui/src/state/view_state.rs
@@ -430,6 +430,20 @@ pub struct MappingUiState {
     /// Inline "Not Collected" editing state.
     /// Set when user is entering/editing a reason for marking a variable as not collected.
     pub not_collected_edit: Option<NotCollectedEdit>,
+    /// Cached filtered variable indices (for performance).
+    /// Contains indices into the domain's variables vec that pass the current filters.
+    pub filtered_indices: Vec<usize>,
+    /// Whether the filtered_indices cache is valid.
+    /// Set to false when filters or underlying data changes.
+    pub cache_valid: bool,
+}
+
+impl MappingUiState {
+    /// Invalidate the filter cache. Call when filters or underlying data changes.
+    #[inline]
+    pub fn invalidate_cache(&mut self) {
+        self.cache_valid = false;
+    }
 }
 
 /// State for inline "Not Collected" reason editing.
@@ -463,6 +477,20 @@ pub struct ValidationUiState {
     pub selected_issue: Option<usize>,
     /// Severity filter.
     pub severity_filter: SeverityFilter,
+    /// Cached filtered issue indices (for performance).
+    /// Contains indices into the validation report's issues vec that pass the current filter.
+    pub filtered_indices: Vec<usize>,
+    /// Whether the filtered_indices cache is valid.
+    /// Set to false when filter or validation results change.
+    pub cache_valid: bool,
+}
+
+impl ValidationUiState {
+    /// Invalidate the filter cache. Call when filter or validation results change.
+    #[inline]
+    pub fn invalidate_cache(&mut self) {
+        self.cache_valid = false;
+    }
 }
 
 /// Filter for validation issue severity.
@@ -542,6 +570,20 @@ pub struct SuppUiState {
     /// When Some, user is editing an included column.
     /// When None, showing read-only view or editing a pending column.
     pub edit_draft: Option<SuppEditDraft>,
+    /// Cached filtered column names (for performance).
+    /// Contains unmapped column names that pass the current filters.
+    pub filtered_columns: Vec<String>,
+    /// Whether the filtered_columns cache is valid.
+    /// Set to false when filters or underlying data changes.
+    pub cache_valid: bool,
+}
+
+impl SuppUiState {
+    /// Invalidate the filter cache. Call when filters or underlying data changes.
+    #[inline]
+    pub fn invalidate_cache(&mut self) {
+        self.cache_valid = false;
+    }
 }
 
 /// Draft state for editing an included SUPP column.


### PR DESCRIPTION
This pull request refactors the toast notification and auto-save mechanisms in the TSS GUI to use event-driven, one-shot timers instead of polling subscriptions. It also introduces helper functions to rebuild filter caches in the domain editor, ensuring UI consistency after relevant data changes. Several code paths now trigger cache rebuilds and auto-save checks more reliably. The subscription system is simplified as a result of these changes.

- Closes: #187 
- Closes: #188 
- Closes: #189 
- Closes: #193 

**Event-driven timers for toast and auto-save:**

- Replaces polling subscriptions for toast auto-dismiss and auto-save debounce with `Task::perform`-based one-shot timers, improving efficiency and responsiveness. The new approach schedules a timer when a toast is shown or when changes are made, rather than polling at fixed intervals. [[1]](diffhunk://#diff-c778c8d32fac74ca6babcf3ecba98bd4a11eee989fa324db06b1e736254cd446L472-R536) [[2]](diffhunk://#diff-74adaaddd72308f8b4ebec7e959d6afc2bd0ed68fd02ce549bf3ad4de1a3fd75L8-R30) [[3]](diffhunk://#diff-74adaaddd72308f8b4ebec7e959d6afc2bd0ed68fd02ce549bf3ad4de1a3fd75L41-L50) [[4]](diffhunk://#diff-74adaaddd72308f8b4ebec7e959d6afc2bd0ed68fd02ce549bf3ad4de1a3fd75L105-L141)

**Domain editor UI cache management:**

- Adds helper functions (`rebuild_mapping_cache`, `rebuild_supp_cache`, `rebuild_validation_cache`) to rebuild filter caches for mapping, SUPP, and validation views, ensuring UI state stays in sync with data changes. These are called after relevant actions in the domain editor. [[1]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bR57-R136) [[2]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bR192-R200) [[3]](diffhunk://#diff-c778c8d32fac74ca6babcf3ecba98bd4a11eee989fa324db06b1e736254cd446R386-R391)

**Improved auto-save and cache rebuild triggers:**

- Updates mapping-related message handlers in the domain editor to rebuild caches and trigger auto-save checks after actions that affect mapping or filters, ensuring that UI and autosave are always up-to-date. [[1]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bR192-R200) [[2]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bL140-R227) [[3]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bL161-R251) [[4]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bL184-R277) [[5]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bL228-R322) [[6]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bL269-R364) [[7]](diffhunk://#diff-73c58745d11475541b4e1193e8a850d832a396092ac1e5ade467e83cd450fd0bL290-R386)

**Subscription system simplification:**

- Removes toast and auto-save polling subscriptions from the main subscription batch, as these are now handled by event-driven timers. Updates documentation and code comments to reflect this architectural change. [[1]](diffhunk://#diff-74adaaddd72308f8b4ebec7e959d6afc2bd0ed68fd02ce549bf3ad4de1a3fd75L8-R30) [[2]](diffhunk://#diff-74adaaddd72308f8b4ebec7e959d6afc2bd0ed68fd02ce549bf3ad4de1a3fd75L41-L50) [[3]](diffhunk://#diff-74adaaddd72308f8b4ebec7e959d6afc2bd0ed68fd02ce549bf3ad4de1a3fd75L105-L141)

**Startup and feedback improvements:**

- Ensures toast notifications (such as update success messages) and toast dismissals are now scheduled as tasks at startup and after relevant events, providing a smoother user experience. [[1]](diffhunk://#diff-c778c8d32fac74ca6babcf3ecba98bd4a11eee989fa324db06b1e736254cd446L67-R72) [[2]](diffhunk://#diff-c778c8d32fac74ca6babcf3ecba98bd4a11eee989fa324db06b1e736254cd446L91-R94) [[3]](diffhunk://#diff-c778c8d32fac74ca6babcf3ecba98bd4a11eee989fa324db06b1e736254cd446L181-R184) [[4]](diffhunk://#diff-c778c8d32fac74ca6babcf3ecba98bd4a11eee989fa324db06b1e736254cd446L312-R322) [[5]](diffhunk://#diff-c778c8d32fac74ca6babcf3ecba98bd4a11eee989fa324db06b1e736254cd446L330-R349)

These changes collectively improve UI responsiveness, reduce unnecessary background work, and make the codebase easier to maintain.